### PR TITLE
🐛 Add remotePattern on replicate.delivery in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,11 @@ module.exports = {
         protocol: "https",
         hostname: "pbxt.replicate.delivery",
       },
+      {
+        protocol: "https",
+        hostname: "replicate.delivery",
+        pathname: '/pbxt/**',
+      },
     ],
   },
   // async headers() {
@@ -21,7 +26,6 @@ module.exports = {
   //           key: 'Content-Security-Policy',
   //           value: "default-src 'self'; img-src 'self' blob: https://replicate.com https://pbxt.replicate.delivery; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; connect-src 'self' blob:;"
   //         }
-                       
   //       ],
   //     },
   //   ];


### PR DESCRIPTION
Fixes image not displayed with REPLICATE_API_TOKEN created on replicate.com